### PR TITLE
Update codecov setup

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -38,9 +38,10 @@ jobs:
     - name: Test with pytest
       run: |
         pytest --cov --cov-config=setup.cfg --cov-report=term --cov-report=xml:coverage.xml
-    - name: Post coverage report
-      run: |
-        codecov
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3
+      env:
+         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     - name: Build docs
       run: |
         cd docs


### PR DESCRIPTION
Github Actions failed, likely due to the repo transfer. Error appeared to be related to codecov so this PR attempts to fix that.