### PR TITLE
add raise to load_spectrum

### DIFF
--- a/astrodbkit2/spectra.py
+++ b/astrodbkit2/spectra.py
@@ -203,5 +203,6 @@ def load_spectrum(filename, spectra_format=None):
     except Exception as e:  # pylint: disable=broad-except, invalid-name
         print(f'Error loading {filename}: {e}')
         spec1d = filename
+        raise Exception(e) 
 
     return spec1d


### PR DESCRIPTION
Right now, if `load_spectrum` fails, it returns the path to the spectrum. It would be more useful if it raised an Exception (of some kind) and passed along the error message. 